### PR TITLE
Fixed bug with filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Material Bottom Tab Navigation component for React Navigation",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "react-native": "src/index.js",
+  "react-native": "src/index.tsx",
   "files": [
     "src",
     "lib"


### PR DESCRIPTION
After updating to version 2.0.0, I could not build the app due to this error: 
> error While trying to resolve module `react-navigation-material-bottom-tabs` from file `[FILE PATH]`, the package `[PATH]/node_modules/react-navigation-material-bottom-tabs/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`[PATH]/node_modules/react-navigation-material-bottom-tabs/src/index.js`. > Indeed, none of these files exist:
>
>  * `/home/giannis/Desktop/Programming/Randomizer/node_modules/react-navigation-material-bottom-tabs/src/index.js(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`
>  * `/home/giannis/Desktop/Programming/Randomizer/node_modules/react-navigation-material-bottom-tabs/src/index.js/index(.native||.android.js|.native.js|.js|.android.json|.native.json|.json|.android.ts|.native.ts|.ts|.android.tsx|.native.tsx|.tsx)`. Run CLI with --verbose flag for more details.

After this change the app is built as expected.

OS: Ubuntu
React Native version: 0.60.5