### PR TITLE
fix: add tabBarColor prop to typedefs

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -34,6 +34,7 @@ export type NavigationMaterialBottomTabOptions = {
   tabBarVisible?: boolean;
   tabBarAccessibilityLabel?: string;
   tabBarTestID?: string;
+  tabBarColor?: string;
   tabBarIcon?:
     | React.ReactNode
     | ((props: {


### PR DESCRIPTION
The functionality works in practice, but says it's not defined. This adds it to the exported types so that it will render in the editor correctly